### PR TITLE
feat: implement coverage report

### DIFF
--- a/template/build.gradle
+++ b/template/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id 'java'
+    id 'jacoco'
+    id 'org.barfuin.gradle.jacocolog' version '2.0.0'
 }
 
 group 'org.bootcamp.template'
@@ -16,4 +18,9 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
 }


### PR DESCRIPTION
Implement JaCoCo coverage report 

# How to use
Just run `./gradlew test` as usual and the coverage report will printed in terminal
