### PR TITLE
[hotifx] fix build failed issue because missing jacoco toolVersion and reportsDir config

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -3,3 +3,4 @@ build/
 .gradle/
 .idea/
 *.class
+jacoco/

--- a/template/build.gradle
+++ b/template/build.gradle
@@ -16,6 +16,11 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 }
 
+jacoco {
+    toolVersion = "0.8.8"
+    reportsDir = file('jacoco')
+}
+
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport


### PR DESCRIPTION
When we run the `./gradlew build` it failed, I made the hotfix, pls review it and lets merge !! 🚀 