### PR TITLE
build: update gradle to build Main class, exclude main from jacoco coverage report

### DIFF
--- a/template/build.gradle
+++ b/template/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
 jacoco {
     toolVersion = "0.8.8"
-    reportsDir = file('jacoco')
+    reportsDirectory = file('jacoco')
 }
 
 test {
@@ -28,4 +28,21 @@ test {
 
 jacocoTestReport {
     dependsOn test
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    "**/Main*",
+            ])
+        }))
+    }
+}
+
+jar {
+    manifest {
+        attributes "Main-Class": "org.bootcamp.template.Main"
+    }
+
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
 }


### PR DESCRIPTION
This excludes `**/Main*` from jacoco coverage report, improvements for the regex is welcome

```
afterEvaluate {
        classDirectories.setFrom(files(classDirectories.files.collect {
            fileTree(dir: it, exclude: [
                    "**/Main*",
            ])
        }))
    }
```

This points at `Main.java` to be your main class so you can actually do `./gradlew build` and properly run the generated `.jar` file. the "template" part will be replaced by the generator script

```
jar {
    manifest {
        attributes "Main-Class": "org.bootcamp.template.Main"
    }

    from {
        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
    }
}
```

This removes a warning when you do any `./gradlew` command because the old `reportsDir` is deprecated

```
reportsDirectory = file('jacoco')
```