### PR TITLE
build: install spotless, run automatically on test and build

### DIFF
--- a/template/build.gradle
+++ b/template/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'org.barfuin.gradle.jacocolog' version '2.0.0'
+    id 'com.diffplug.gradle.spotless' version '4.5.1'
 }
 
 group 'org.bootcamp.template'
@@ -14,6 +15,7 @@ repositories {
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    implementation 'com.google.googlejavaformat:google-java-format:1.9'
 }
 
 jacoco {
@@ -23,9 +25,23 @@ jacoco {
 
 test {
     useJUnitPlatform()
+    dependsOn spotlessApply
     finalizedBy jacocoTestReport
+}
+
+jar {
+    dependsOn spotlessApply
 }
 
 jacocoTestReport {
     dependsOn test
+}
+
+spotless {
+    java {
+        googleJavaFormat()
+        trimTrailingWhitespace()
+        indentWithSpaces(2)
+        endWithNewline()
+    }
 }

--- a/template/gradle.properties
+++ b/template/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED


### PR DESCRIPTION
# PROPOSAL

THIS NEEDS TO BE DISCUSSED FIRST

## spotless

spotless is like rubocop but for java

## reason

right now we're either forgetting or doing 1 of these:

1. do cmd+opt+L manually on every single file before every single commit
2. edit intellij preferences > version control > before commit > reformat etc (this only works if u commit through intellij's gui, it does not work if you commit through cmd line, including the terminal inside intellij)
3. edit intellij preferences > tools > actions on save > reformat etc (we must do cmd+S before every commit)

but if we use spotless, our code will be reformatted everytime we `./gradlew test` or `./gradlew build`, we will also have a `.pre-commit-config.yaml` (assuming #10 and #7 is merged) that will run `./gradlew test` before every commit. this way we wont have to think about formatting at all since it will just be reformatted when we want to commit it (except for our newline convention).

## problem

we are now using a mix of google's style and intellij due to importing google's XML file into intellij, this mix has lead to some conflicts, such as

```java
// spotless
public SomeClass() {}

// intellij
public SomeClass() {
}
```

``` java
// spotless, newline after class is optional, so this is allowed
class SomeClass {
  private String firstAttribute
  ...
}

// intellij
class SomeClass {

  private String firstAttribute
  ...
}
```

we also have our own whitespace convention that might conflict with spotless

## solutions

some solutions we found so far:

- use spotless as our only linting tool, basically like rubocop
- use spotless as our main linting tool, having higher priority over intellij and our convention
- somehow mix spotless, intellij, and our convention
- stay with the old system of (trying to) not forget to press cmd+opt+L or cmd+S everytime

give me ur thoughts

## gradle

this runs `./gradlew spotlessApply` before every `./gradlew test`

```
test {
    useJUnitPlatform()
    dependsOn spotlessApply
    finalizedBy jacocoTestReport
}
```

this does the same thing but before every `./gradlew build`

```
jar {
    dependsOn spotlessApply
}
```

`./gradlew spotlessApply` is just like `rubocop -a` or `rubocop -A` in ruby
