### PR TITLE
feat: add new precommit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   -   repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v2.3.0
+      rev: v4.3.0
       hooks:
         -   id: end-of-file-fixer
         -   id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  -   repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v2.3.0
+      hooks:
+        -   id: end-of-file-fixer
+        -   id: trailing-whitespace
+  - repo: local
+    hooks:
+      - id: gradle-test
+        name: test with this project's gradlew
+        entry: ./gradlew test
+        language: system
+        types: [java]
+        pass_filenames: false


### PR DESCRIPTION
Fixes newline at end of file

```
-   repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v4.3.0
    hooks:
      -   id: end-of-file-fixer
      -   id: trailing-whitespace 
```

Runs `./gradlew test` and will not allow you to commit until all tests pass

```
- repo: local
  hooks:
    - id: gradle-test
      name: test with this project's gradlew
      entry: ./gradlew test
      language: system
      types: [java]
      pass_filenames: false
```

The previous google-style-java commit hook ([this one](https://github.com/ThomasKoppensteiner/google-style-precommit-hook/)) as seen on our wiki has a better alternative at PR #9 (official repo [here](https://github.com/google/google-java-format)) hence it is removed from here under the assumption that that PR is merged